### PR TITLE
Missing newline impacting RTD rendering

### DIFF
--- a/docs/source/examples/Notebook/Distributing Jupyter Extensions as Python Packages.ipynb
+++ b/docs/source/examples/Notebook/Distributing Jupyter Extensions as Python Packages.ipynb
@@ -159,6 +159,7 @@
    "source": [
     "### Defining the server extension\n",
     "This example shows that the server extension and its `load_jupyter_server_extension` function are defined in the `__init__.py` file.\n",
+    "\n",
     "#### `my_module/__init__.py`\n",
     "\n",
     "```python\n",


### PR DESCRIPTION
The specific issue is highlighted in the attached screenshot where hashmarks are shown instead of a header, specifically: "`__init__.py` file. #### `my_module/__init__.py`"

![screen shot 2016-04-15 at 3 51 37 pm](https://cloud.githubusercontent.com/assets/474290/14576896/51bbbfb2-0322-11e6-8671-b040f7ecfa0c.png)
